### PR TITLE
Added section of third-party tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@ Are you having DNS problems? These lists contains the same trackers but with IP 
 * Do you know more public trackers? => [Open a new issue](https://github.com/ngosang/trackerslist/issues/new)
 * Any of the trackers is not working properly? => [Open a new issue](https://github.com/ngosang/trackerslist/issues/new)
 
+##### Third-party tools
+* [Bash script](https://github.com/oilervoss/openwrt/tree/master/transmission) for transmission-remote to read ngosang's lists and add them.
+
 ##### Contact
 ngosang [@] hotmail [.es]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Are you having DNS problems? These lists contains the same trackers but with IP 
 * Any of the trackers is not working properly? => [Open a new issue](https://github.com/ngosang/trackerslist/issues/new)
 
 ##### Third-party tools
-* [Bash script](https://github.com/oilervoss/openwrt/tree/master/transmission) for transmission-remote to read ngosang's lists and add them.
+* [Bash script](https://github.com/oilervoss/openwrt/tree/transmission) for transmission-remote to read ngosang's lists and add them.
 
 ##### Contact
 ngosang [@] hotmail [.es]


### PR DESCRIPTION
I added a section in the main README to list tools that use ngosang's lists. I listed a bash script for transmission-remote that search torrents by part of name, read ngosang's list and add the trackers to the torrent