### PR TITLE
Add brand-new tracker

### DIFF
--- a/trackers_all_ws.txt
+++ b/trackers_all_ws.txt
@@ -15,4 +15,5 @@ ws://tracker.sloppyta.co:80/announce
 ws://tracker.files.fm:7072/announce
 
 ws://hub.bugout.link:80/announce
-
+ 
+wss://spacetradersapi-chatbox.herokuapp.com:443/announce


### PR DESCRIPTION
The tracker has only ever been used once (by me).
Uses herokuapp, but oh well. Consider removing hub.bugout.link to compensate. ( The bugout devs are really mad at you. See chr15m/bugout#42 ).

Tracker:

`wss://spacetradersapi-chatbox.herokuapp.com:443/announce`

You guys can probably squeeze out about 100 users without killing it.