### PR TITLE
Remove wss://peertube.cpy.re

### DIFF
--- a/trackers_all_ws.txt
+++ b/trackers_all_ws.txt
@@ -2,7 +2,5 @@ wss://tracker.files.fm:7073/announce
 
 wss://spacetradersapi-chatbox.herokuapp.com:443/announce
 
-wss://peertube.cpy.re:443/tracker/socket
-
 ws://tracker.files.fm:7072/announce
 


### PR DESCRIPTION
This is not a public tracker. It won't answer to unknown infohash