### PR TITLE
Added my magnet editor to the list of the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ ngosang [@] hotmail [.es]
 
 ### Third-party online tools
 * [torrenteditor](http://torrenteditor.com) to add these trackers to your .torrent files
+* [magnets](https://4ndv.github.io/magnets) to add these trackers to your magnet links


### PR DESCRIPTION
I (sometimes) develop an opensource web-based magnet links editor, that can automagically add trackers from trackerslist to the magnet links: https://github.com/4ndv/magnets

Added a link to it the "third-party online tools" section of the readme :)