### PR TITLE
Add torrenttrackerslist.com under Third-party online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ ngosang [@] hotmail [.es]
 ### Third-party online tools
 * [torrenteditor](http://torrenteditor.com) to add these trackers to your .torrent files
 * [magnets](https://madeby.lynx.pink/magnets/) to add these trackers to your magnet links
+* [Torrent Trackers List](https://www.torrenttrackerslist.com) — paste the trackers from your .torrent/magnet and get live up/down + round-trip latency per tracker. Uses `trackers_all.txt` from this repo as upstream truth (credited on-site).


### PR DESCRIPTION
Hi @ngosang — long-time consumer of your list here, thanks for keeping it
maintained.

This PR adds one line under **Third-party online tools** for
https://www.torrenttrackerslist.com — a web UI that:

- pulls `trackers_all.txt` from this repo as upstream truth (credited on-site)
- lets a user paste the trackers already in their `.torrent` / magnet and
  reports live up/down + round-trip latency per tracker
- offers one-click copy formatted for qBittorrent, µTorrent and Deluge

It complements the repo rather than replacing it — people who want the raw
.txt still come here; people who want "is tracker X up right now?" get an
answer without spinning up their own checker.

Happy to tweak the wording, move it to a different section, or close this if
you'd rather not list web frontends. No hard feelings either way — and
thanks again for the list.
